### PR TITLE
Set groups on discourse from LDAP

### DIFF
--- a/config.env.py
+++ b/config.env.py
@@ -40,4 +40,4 @@ SSO_EMAIL_OVERRIDE_DOMAIN = os.environ.get('SSO_EMAIL_OVERRIDE_DOMAIN', '')
 # Attribute to read from the environment after user validation
 DISCOURSE_USER_MAP = json.loads(os.environ.get('SSO_DISCOURSE_USER_MAP',
                                                '{"name": ["givenName", "sn"], "username": "preferred_username", \
-                                               "external_id": "sub", "email": "email"}'))
+                                               "external_id": "sub", "email": "email", "groups": "groups"}'))

--- a/src/discourseOIDC/sso.py
+++ b/src/discourseOIDC/sso.py
@@ -149,6 +149,11 @@ def user_auth():
     if not username:
         username = (name.replace(' ', '') + '_' + external_id[0:4])
 
+    # Groups
+    groups = None
+    if 'groups' in attribute_map:
+        groups = session['userinfo'].get(attribute_map['groups'], [])
+
     # Email
     email = session['userinfo'].get(attribute_map['email'], '')
     if app.config.get('SSO_EMAIL_OVERRIDE', False):
@@ -167,10 +172,12 @@ def user_auth():
 
     # Build response
     query = (session['discourse_nonce'] +
-             '&name=' + name +
-             '&username=' + username +
+             '&name=' + quote(name) +
+             '&username=' + quote(username) +
              '&email=' + quote(email) +
-             '&external_id=' + external_id)
+             '&external_id=' + quote(external_id))
+    if groups is not None:
+        query += '&groups=' + quote(','.join(groups))
     app.logger.debug('Query string to return: %s', query)
 
     # Encode response


### PR DESCRIPTION
not sure why we weren't doing this, I assume when we moved to discourse we just never continued doing this.

I renamed a few groups on discourse (webmasters -> webmaster, secretary -> eboard-secretary) to match their discourse group names

pls don't merge before opcomm :pleading_face: 